### PR TITLE
fix: incorrect output of toHanYuPinyinString when retain=false

### DIFF
--- a/src/main/java/net/sourceforge/pinyin4j/PinyinHelper.java
+++ b/src/main/java/net/sourceforge/pinyin4j/PinyinHelper.java
@@ -291,12 +291,12 @@ public class PinyinHelper {
         if (retain) {
           resultPinyinStrBuf.append(chars[i]);
         }
-        if (i > 0 && !retainSeparator && lastHasResult) {
+        if (i > 0 && retain && !retainSeparator && lastHasResult) {
           resultPinyinStrBuf.delete(resultPinyinStrBuf.length() - 1 - separate.length(),
               resultPinyinStrBuf.length() - 1);
         }
       } else {
-        if (i > 0 && retainSeparator && !lastHasResult) {
+        if (i > 0 && retain && retainSeparator && !lastHasResult) {
           if (current < chars.length) {
             resultPinyinStrBuf.append(separate);
           }

--- a/src/test/java/net/sourceforge/pinyin4j/test/NewPinyinHelperTest.java
+++ b/src/test/java/net/sourceforge/pinyin4j/test/NewPinyinHelperTest.java
@@ -47,6 +47,15 @@ public class NewPinyinHelperTest {
 
     String result6 = PinyinHelper.toHanYuPinyinString("浅浅淡淡ω", format, " ", true, true);
     assertEquals("jiān jiān dàn dàn ω", result6);
+
+
+
+    assertEquals("yī rì qiān lĭ",
+            PinyinHelper.toHanYuPinyinString("一日,千里", format, " ", false, false));
+
+    assertEquals("yī rì qiān lĭ",
+            PinyinHelper.toHanYuPinyinString("一日,千里", format, " ", false, true));
+
   }
 
 }


### PR DESCRIPTION
修正了如下bug：
```
PinyinHelper.toHanYuPinyinString("一日,千里", format, " ", false, false)
// "yī r qiān lĭ"    日字只剩下一个r
PinyinHelper.toHanYuPinyinString("一日,千里", format, " ", false, true)
// "yī rì  qiān lĭ"   日字后有两个空格
```
