### PR TITLE
fix: incorrect output of toHanYuPinyinString

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 ## pinyin4j
 
 #### 项目来源
-本项目基于 pinyin4j 和 belerweb.pinyin4j 进行再次封装改造。   
+本项目基于 pinyin4j ,belerweb.pinyin4j, wnjustdoit.pinyin4j 进行再次封装改造。   
 * http://sourceforge.net/projects/pinyin4j （原始）
 * https://github.com/belerweb/pinyin4j （二次封装，但已经不维护了，有部分缺陷）
+* https://github.com/wnjustdoit/pinyin4j (有一些缺陷, 但提不了Issue, PR没响应)
 
 #### maven坐标
 ```
         <dependency>
-            <groupId>io.github.wnjustdoit</groupId>
+            <groupId>io.github.zhangethan</groupId>
             <artifactId>pinyin4j</artifactId>
-            <version>2.6.0</version>
+            <version>2.6.1</version>
         </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,42 +63,9 @@
 
     <profiles>
         <profile>
-            <id>local</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.22.2</version>
-                        <configuration>
-                            <skip>true</skip>
-                            <skipTests>true</skipTests>
-                            <testFailureIgnore>true</testFailureIgnore>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>release</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
+                <activeByDefault>true</activeByDefault>
             </activation>
             <build>
                 <plugins>
@@ -180,8 +147,8 @@
                         <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>sonatype-nexus-staging</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
@@ -239,12 +206,12 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
-            <id>sonatype-nexus-staging</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,16 +9,16 @@
         <version>7</version>
     </parent>
 
-    <groupId>io.github.wnjustdoit</groupId>
+    <groupId>io.github.zhangethan</groupId>
     <artifactId>pinyin4j</artifactId>
-    <version>2.6.0</version>
+    <version>2.6.1</version>
 
     <name>Chinese to Pinyin</name>
     <description>Support Chinese character (both Simplified and Tranditional) to most popular Pinyin systems, including
         Hanyu Pinyin, Tongyong Pinyin, Wade-Giles, MPS2, Yale and Gwoyeu Romatzyh. Support multiple pronounciations and
         customized output.
     </description>
-    <url>https://github.com/wnjustdoit/pinyin4j</url>
+    <url>https://github.com/zhangethan/pinyin4j</url>
 
     <licenses>
         <license>
@@ -29,20 +29,20 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:https://github.com/wnjustdoit/pinyin4j.git</connection>
-        <developerConnection>scm:git:https://github.com/wnjustdoit/pinyin4j.git</developerConnection>
-        <url>https://github.com/wnjustdoit/pinyin4j.git</url>
+        <connection>scm:git:https://github.com/zhangethan/pinyin4j.git</connection>
+        <developerConnection>scm:git:https://github.com/zhangethan/pinyin4j.git</developerConnection>
+        <url>https://github.com/zhangethan/pinyin4j.git</url>
     </scm>
     <issueManagement>
         <system>Github Issue</system>
-        <url>https://github.com/wnjustdoit/pinyin4j/issues</url>
+        <url>https://github.com/zhangethan/pinyin4j/issues</url>
     </issueManagement>
     <developers>
         <developer>
-            <id>wnjustdoit</id>
-            <name>Nan Wang</name>
-            <email>wnjustdoit@gmail.com</email>
-            <url>https://github.com/wnjustdoit</url>
+            <id>zhangethan</id>
+            <name>Zhang Ethan</name>
+            <email>joychen888@gmail.com</email>
+            <url>https://github.com/zhangethan</url>
         </developer>
     </developers>
 
@@ -63,9 +63,42 @@
 
     <profiles>
         <profile>
-            <id>release</id>
+            <id>local</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.22.2</version>
+                        <configuration>
+                            <skip>true</skip>
+                            <skipTests>true</skipTests>
+                            <testFailureIgnore>true</testFailureIgnore>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>release</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <build>
                 <plugins>

--- a/src/main/java/net/sourceforge/pinyin4j/PinyinHelper.java
+++ b/src/main/java/net/sourceforge/pinyin4j/PinyinHelper.java
@@ -291,12 +291,12 @@ public class PinyinHelper {
         if (retain) {
           resultPinyinStrBuf.append(chars[i]);
         }
-        if (i > 0 && !retainSeparator && lastHasResult) {
+        if (i > 0 && retain && !retainSeparator && lastHasResult) {
           resultPinyinStrBuf.delete(resultPinyinStrBuf.length() - 1 - separate.length(),
               resultPinyinStrBuf.length() - 1);
         }
       } else {
-        if (i > 0 && retainSeparator && !lastHasResult) {
+        if (i > 0 && retain && retainSeparator && !lastHasResult) {
           if (current < chars.length) {
             resultPinyinStrBuf.append(separate);
           }

--- a/src/test/java/net/sourceforge/pinyin4j/test/NewPinyinHelperTest.java
+++ b/src/test/java/net/sourceforge/pinyin4j/test/NewPinyinHelperTest.java
@@ -56,6 +56,12 @@ public class NewPinyinHelperTest {
     assertEquals("yī rì qiān lĭ",
             PinyinHelper.toHanYuPinyinString("一日,千里", format, " ", false, true));
 
+    assertEquals("yī rì qiān lĭ",
+            PinyinHelper.toHanYuPinyinString(",一日千里", format, " ", false, false));
+
+    assertEquals("yī rì qiān lĭ",
+            PinyinHelper.toHanYuPinyinString(",一日,千里,", format, " ", false, false));
+
   }
 
 }

--- a/src/test/java/net/sourceforge/pinyin4j/test/NewPinyinHelperTest.java
+++ b/src/test/java/net/sourceforge/pinyin4j/test/NewPinyinHelperTest.java
@@ -47,6 +47,15 @@ public class NewPinyinHelperTest {
 
     String result6 = PinyinHelper.toHanYuPinyinString("浅浅淡淡ω", format, " ", true, true);
     assertEquals("jiān jiān dàn dàn ω", result6);
+
+
+
+    assertEquals("yī rì qiān lĭ",
+            PinyinHelper.toHanYuPinyinString("一日,千里", format, " ", false, false));
+
+    assertEquals("yī rì qiān lĭ",
+            PinyinHelper.toHanYuPinyinString("一日,千里", format, " ", false, true));
+
   }
 
 }


### PR DESCRIPTION
修复以下bug
```
PinyinHelper.toHanYuPinyinString("一日,千里", format, " ", false, false)
// "yī r qiān lĭ"    日字只剩下一个r
PinyinHelper.toHanYuPinyinString("一日,千里", format, " ", false, true)
// "yī rì  qiān lĭ"   日字后有两个空格
```